### PR TITLE
Fix search_data_dict tests due to data dictionary updates

### DIFF
--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -25,10 +25,12 @@ test_that("get_data saves a local copy of the data which can then be successfull
 })
 
 test_that("get_data can download data using utils alternative", {
+  
   tb_data_utils <- get_data(url = url,
                             download_data = TRUE,
                             use_utils = TRUE)
   
+  skip_on_cran()
   expect_true(!is.null(tb_data_utils))
 })
 

--- a/tests/testthat/test-get_data_dict.R
+++ b/tests/testthat/test-get_data_dict.R
@@ -29,11 +29,12 @@ test_that("Data dictionary has at least the expected number of entries", {
 
 test_that("Data dictionary is the same when downloaded using utils::read.csv.
           Not testing definitions as encoded differently", {
-            skip_on_cran()
+
   data_dict_utils <- get_data_dict(download_data = TRUE,
                                    use_utils = TRUE,
                                    dict_save_name = "dict_with_utils")
-
+  
+  skip_on_cran()
   expect_equal(data_dict[-ncol(data_dict)], data_dict_utils[,-ncol(data_dict_utils)])
   
 })

--- a/tests/testthat/test-get_data_dict.R
+++ b/tests/testthat/test-get_data_dict.R
@@ -8,7 +8,7 @@ ncols_dict <- ncol(data_dict)
 nrows_dict <-  nrow(data_dict)
 class_dict <- class(data_dict)[1]
 ## Expected
-exp_nrows <- 396
+exp_nrows <- 300
 exp_ncols <- 4
 exp_class <- "tbl_df"
 
@@ -19,16 +19,17 @@ test_that("Data dictionary is a tibble",{
   expect_equal(exp_class, class_dict)
 })
 
-test_that("Data dictionary has the expected number of variables", {
-  expect_equal(exp_ncols, ncols_dict)
+test_that("Data dictionary has at least the expected number of variables", {
+  expect_true(exp_ncols <= ncols_dict)
 })
 
-test_that("Data dictionary has the expected number of entries", {
-  expect_equal(exp_nrows, nrows_dict)
+test_that("Data dictionary has at least the expected number of entries", {
+  expect_true(exp_nrows <= nrows_dict)
 })
 
 test_that("Data dictionary is the same when downloaded using utils::read.csv.
           Not testing definitions as encoded differently", {
+            skip_on_cran()
   data_dict_utils <- get_data_dict(download_data = TRUE,
                                    use_utils = TRUE,
                                    dict_save_name = "dict_with_utils")

--- a/tests/testthat/test-get_tb_burden.R
+++ b/tests/testthat/test-get_tb_burden.R
@@ -33,5 +33,6 @@ test_that("TB burden data is the same when downloaded using utils::read.csv", {
                                  use_utils = TRUE,
                                  burden_save_name = "TB_with_utils")
   
+  skip_on_cran()
   expect_equal(tb_data, tb_data_utils)
 })

--- a/tests/testthat/test-search_data_dict.R
+++ b/tests/testthat/test-search_data_dict.R
@@ -1,6 +1,8 @@
 context("search_data_dict")
 
 
+## Test dictionary
+
 ## Search for a known variable
 test_var <- search_data_dict(var = "country", download_data = TRUE, save = TRUE)
 
@@ -13,13 +15,14 @@ exp_var <- tibble::tibble(variable_name = "country",
 ## Search for all variables mentioning mortality in their definition
 test_def <- search_data_dict(def = "mortality")
 
-exp_def <- c("e_mort_exc_tbhiv_100k", "e_mort_exc_tbhiv_100k_hi",
+exp_def <- c("e_mort_100k", "e_mort_100k_hi", "e_mort_100k_lo",
+             "e_mort_exc_tbhiv_100k", "e_mort_exc_tbhiv_100k_hi",
              "e_mort_exc_tbhiv_100k_lo", "e_mort_tbhiv_100k",
              "e_mort_tbhiv_100k_hi", "e_mort_tbhiv_100k_lo")
 
 ## Search for both a known variable and for mortality being mentioned in there definition
 ## Duplicate entries will be omitted.
-test_var_def <- search_data_dict(var = "e_mort_exc_tbhiv_100k", def = "mortality")
+test_var_def <- search_data_dict(var = "e_mort_100k", def = "mortality")
 
 test_that("Variable search for a known variable returns expected results", {
   expect_equal(exp_var, test_var)
@@ -28,15 +31,15 @@ test_that("Variable search for a known variable returns expected results", {
 test_that("Definition search for an unknown variable returns expected results", {
   expect_true(!is.null(test_def))
   expect_equal("tbl_df", class(test_def)[1])
-  expect_equal(6, nrow(test_def))
-  expect_equal(4, ncol(test_def))
+  expect_true(9 <= nrow(test_def))
+  expect_true(4 <= ncol(test_def))
   expect_equal(exp_def, test_def$variable_name)
 })
 
 test_that("Combined variable and definition search returns expected results", {
   expect_true(!is.null(test_var_def))
   expect_equal("tbl_df", class(test_var_def)[1])
-  expect_equal(6, nrow(test_var_def))
-  expect_equal(4, ncol(test_var_def))
+  expect_true(9 <= nrow(test_var_def))
+  expect_true(4 <= ncol(test_var_def))
   expect_equal(exp_def, test_var_def$variable_name)
 })


### PR DESCRIPTION
The WHO have updated the backend data dictionary, package tests are brittle and required updating. To limit future breaks tests have been updated but tests remain brittle.